### PR TITLE
Updated to use task concepts to execute JPA startup

### DIFF
--- a/src/main/java/pas/au/pivotal/pa/sct/demo/SpringCloudTaskTodaysDateApplication.java
+++ b/src/main/java/pas/au/pivotal/pa/sct/demo/SpringCloudTaskTodaysDateApplication.java
@@ -2,14 +2,10 @@ package pas.au.pivotal.pa.sct.demo;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.springframework.beans.factory.annotation.Autowired;
+
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.task.configuration.EnableTask;
-
-import javax.annotation.PostConstruct;
-import java.text.SimpleDateFormat;
-import java.util.Date;
 
 @SpringBootApplication
 @EnableTask
@@ -17,24 +13,7 @@ public class SpringCloudTaskTodaysDateApplication  {
 
 	private static final Log logger = LogFactory.getLog(SpringCloudTaskTodaysDateApplication.class);
 
-	private TaskRunRepository taskRunRepository;
-
-	@Autowired
-	public SpringCloudTaskTodaysDateApplication (TaskRunRepository taskRunRepository)
-	{
-		this.taskRunRepository = taskRunRepository;
-	}
-
 	public static void main(String[] args) {
 		SpringApplication.run(SpringCloudTaskTodaysDateApplication.class, args);
 	}
-
-	@PostConstruct
-	public void init()
-	{
-		String execDate = new SimpleDateFormat().format(new Date());
-		taskRunRepository.save(new TaskRunOutput("Executed at " + execDate));
-		logger.info("Executed at : " + execDate);
-	}
-
 }

--- a/src/main/java/pas/au/pivotal/pa/sct/demo/configuration/JpaTaskConfigurer.java
+++ b/src/main/java/pas/au/pivotal/pa/sct/demo/configuration/JpaTaskConfigurer.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package pas.au.pivotal.pa.sct.demo.configuration;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import pas.au.pivotal.pa.sct.demo.TaskRunOutput;
+import pas.au.pivotal.pa.sct.demo.TaskRunRepository;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.task.configuration.DefaultTaskConfigurer;
+import org.springframework.cloud.task.listener.annotation.BeforeTask;
+import org.springframework.cloud.task.repository.TaskExecution;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.PlatformTransactionManager;
+
+/**
+ * @author Michael Minella
+ */
+@Component
+public class JpaTaskConfigurer extends DefaultTaskConfigurer {
+	private static final Log logger = LogFactory.getLog(JpaTaskConfigurer.class);
+
+	@Autowired
+	private PlatformTransactionManager transactionManager;
+
+	@Autowired
+	private TaskRunRepository taskRunRepository;
+
+	@Override
+	public PlatformTransactionManager getTransactionManager() {
+		if(this.transactionManager == null) {
+			this.transactionManager = new JpaTransactionManager();
+		}
+
+		return this.transactionManager;
+	}
+
+	@BeforeTask
+	public void init(TaskExecution taskExecution)
+	{
+		String execDate = new SimpleDateFormat().format(new Date());
+		taskRunRepository.save(new TaskRunOutput("Executed at " + execDate));
+		logger.info("Executed at : " + execDate);
+	}
+}


### PR DESCRIPTION
This updates the application to use Spring Cloud Task idioms to address the previously requested functionality.  Let me know if this helps or if there's anything else you think we should do to address this for future users.